### PR TITLE
applaunchservices 0.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-    c3i_test2: pyobjc_dev
+#channels:
+#    c3i_test2: pyobjc_dev

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    c3i_test2: pyobjc_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "applaunchservices" %}
-{% set version = "0.2.1" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +7,31 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3da9d5435aec18eb70000f51cdf5ca428ba4bf03f36d922eb04635f8b5af4296
+  sha256: 1cc6ad5c6c88457230b3cc3d1f76c39c00dcd2597af9c6ee592dce5e67eb2cad
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  # [not osx]
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
+    - pyobjc-framework-coreservices
 
 test:
   imports:
     - applaunchservices
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/impact27/applaunchservices
@@ -32,6 +40,7 @@ about:
   license_file: LICENSE.txt
   summary: 'Simple package for registering an app with apple Launch Services to handle UTI and URL'
   dev_url: https://github.com/impact27/applaunchservices
+  doc_url: https://github.com/impact27/applaunchservices/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/impact27/applaunchservices/blob/master/LICENSE.txt
Requirements: https://github.com/impact27/applaunchservices/blob/master/setup.py


Actions:
1. Remove `noarch: python`
2. Skip `py<36` & `not osx`
3. Add `setuptools` & `wheel` to `host`
4. Add `pyobjc-framework-coreservices` to `run`
5. Add `pip check`
6. Add `doc_url`